### PR TITLE
Setup paton for continuous benchmarking

### DIFF
--- a/.github/workflows/paton-benchmark.yml
+++ b/.github/workflows/paton-benchmark.yml
@@ -4,15 +4,9 @@ on:
     branches:
       - master
   pull_request:
-# For demonstration purposes, allow paton to run on all PRs.
-#    branches:
-#      - master
-permissions:
-  contents: write
-  deployments: write
+
 jobs:
-  paton:
-    name: paton
+  paton-benchmark:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -45,6 +39,12 @@ jobs:
         with:
           name: alerting_benchmarks.json
           path: /tmp/alerting_benchmarks.json
+      - run: echo ${{ github.event.number }} > /tmp/pr_number.txt
+        shell: bash
+      - uses: actions/upload-artifact@v3
+        with:
+          name: pr_number.txt
+          path: /tmp/pr_number.txt
 #      - name: Check files
 #        id: check_files
 #        uses: andstor/file-existence-action@v1

--- a/.github/workflows/paton-comment.yml
+++ b/.github/workflows/paton-comment.yml
@@ -1,0 +1,38 @@
+name: "paton comment"
+on:
+  workflow_run:
+    workflows: ["paton benchmark"]
+    types:
+      - completed
+
+jobs:
+  paton-comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+    steps:
+      - id: download-artifact
+        uses: dawidd6/action-download-artifact@v2
+        with: paton.yml
+        name: alerting_benchmarks.json
+        path: /tmp/alerting_benchmarks.json
+      - name: Run benchmark
+        run: if [ ! -s /tmp/alerting_benchmarks.json ]; then rm /tmp/alerting_benchmarks.json
+        shell: bash
+      - name: Check files
+        id: check_files
+        uses: andstor/file-existence-action@v1
+        with:
+          files: "/tmp/alerting_benchmarks.json"
+      - uses: peter-evans/create-or-update-comment@v2
+        with:
+          issue-number: ${{ github.event.number }}
+          body-file: /tmp/alerting_benchmarks.json
+
+ #     - name: Slack Notification
+ #       env:
+ #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+ #       run: |
+ #         curl -X POST --data-urlencode "payload={\"text\": \"Benchmark workflow failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+  #      if: ${{ failure() && (contains(github.ref_name, 'rel/nightly') || contains(github.ref_name, 'rel/beta') || contains(github.ref_name, 'rel/stable') || contains(github.ref_name, 'master')) }}

--- a/.github/workflows/paton-comment.yml
+++ b/.github/workflows/paton-comment.yml
@@ -12,22 +12,26 @@ jobs:
       github.event.workflow_run.event == 'pull_request' &&
       github.event.workflow_run.conclusion == 'success'
     steps:
-      - id: download-artifact
-        uses: dawidd6/action-download-artifact@v2
-        with: paton.yml
+      - uses: dawidd6/action-download-artifact@v2
+        with: paton-benchmark.yml
         name: alerting_benchmarks.json
         path: /tmp/alerting_benchmarks.json
-      - name: Run benchmark
-        run: if [ ! -s /tmp/alerting_benchmarks.json ]; then rm /tmp/alerting_benchmarks.json
+      - run: if [ ! -s /tmp/alerting_benchmarks.json ]; then rm /tmp/alerting_benchmarks.json
         shell: bash
-      - name: Check files
-        id: check_files
+      - id: check_benchmark
         uses: andstor/file-existence-action@v1
         with:
           files: "/tmp/alerting_benchmarks.json"
+      - uses: dawidd6/action-download-artifact@v2
+        with: paton-benchmark.yml
+        name: pr_number.txt
+        path: /tmp/pr_number.txt
+      - run: echo "pr_number=$(cat /tmp/pr_number.txt)" >> $GITHUB_ENV
+        shell: bash
       - uses: peter-evans/create-or-update-comment@v2
+        if: steps.check_benchmark.outputs.files_exists == 'true'
         with:
-          issue-number: 5 # TODO Provide dynamically
+          issue-number: "{{ env.pr_number }}"
           body-file: /tmp/alerting_benchmarks.json
 
  #     - name: Slack Notification

--- a/.github/workflows/paton-comment.yml
+++ b/.github/workflows/paton-comment.yml
@@ -27,7 +27,7 @@ jobs:
           files: "/tmp/alerting_benchmarks.json"
       - uses: peter-evans/create-or-update-comment@v2
         with:
-          issue-number: ${{ github.event.number }}
+          issue-number: 5 # TODO Provide dynamically
           body-file: /tmp/alerting_benchmarks.json
 
  #     - name: Slack Notification

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -31,9 +31,9 @@ jobs:
         shell: bash
       - run: ./scripts/travis/before_build.sh # Installs libsodium.
         shell: bash
- #     - name: Run benchmark
- #       run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
- #       shell: bash
+      - name: Run benchmark
+        run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
+        shell: bash
       - name: Push benchmark result to gh-pages branch
         if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1
@@ -43,16 +43,16 @@ jobs:
           output-file-path: /tmp/benchstat_time_jq.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-#      - name: Evaluate benchmark on PR branch
-#        if: github.event.pull_request
-#        uses: benchmark-action/github-action-benchmark@v1
-#        with:
-#          name: Go Benchmark
-#          tool: 'customSmallerIsBetter'
-#          output-file-path: /tmp/benchstat_time_jq.json
-#          github-token: ${{ secrets.GITHUB_TOKEN }}
-#          alert-threshold: '10%'
-#          comment-on-alert: true
+      - name: Evaluate benchmark on PR branch
+        if: github.event.pull_request
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'customSmallerIsBetter'
+          output-file-path: /tmp/benchstat_time_jq.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '10%'
+          comment-on-alert: true
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -24,7 +24,6 @@ jobs:
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq
-      - run: sh scripts/configure_dev.sh
       - run: sh scripts/buildtools/install_buildtools.sh
       - run: sh scripts/travis/before_build.sh # Installs libsodium.
       - name: Run benchmark

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -21,6 +21,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
+          cache: true
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -22,6 +22,12 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
+      - name: Restore libsodium from cache
+        id: cache-libsodium
+        uses: actions/cache@v3
+        with:
+          path: crypto/libs
+          key: libsodium-fork-v1-${{ runner.os }}-${{ hashFiles('crypto/libsodium-fork/**') }}
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jq python3-pip

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -46,16 +46,11 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: "/tmp/alerting_benchmarks.json"
-      - uses: actions/github-script@v6
+      - uses: peter-evans/commit-comment@v2
         if: steps.check_files.outputs.files_exists == 'true'
         with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Performance degraded!'
-            })
+          body: |
+            Performance degraded!
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -24,7 +24,8 @@ jobs:
           cache: true
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
-      - run: sudo apt-get -y -q install jc jq
+      - run: sudo apt-get -y -q install jq python3-pip
+      - run: pip3 install jc # Use pip to install jc because aptitude is stale (https://repology.org/project/jc/versions)
       - run: ./scripts/configure_dev.sh
         shell: bash
       - run: ./scripts/buildtools/install_buildtools.sh

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -24,7 +24,11 @@ jobs:
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq
-      - run: sh scripts/travis/before_build.sh # Installs libsodium.
+      - run: |
+        scripts/configure_dev.sh
+        scripts/buildtools/install_buildtools.sh
+        scripts/travis/before_build.sh # Installs libsodium.
+        shell: bash
       - name: Run benchmark
         run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -1,4 +1,4 @@
-name: "Benchmark workflow"
+name: "paton benchmark"
 on:
   push:
     branches:
@@ -41,16 +41,15 @@ jobs:
       - name: Run benchmark
         run: ./scripts/paton.sh --alert-threshold-pct 10 --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash
-      - name: Check files
-        id: check_files
-        uses: andstor/file-existence-action@v1
+      - uses: actions/upload-artifact@v3
         with:
-          files: "/tmp/alerting_benchmarks.json"
-      - uses: peter-evans/commit-comment@v2
-        if: steps.check_files.outputs.files_exists == 'true'
-        with:
-          body: |
-            Performance degraded!
+          name: alerting_benchmarks.json
+          path: /tmp/alerting_benchmarks.json
+#      - name: Check files
+#        id: check_files
+#        uses: andstor/file-existence-action@v1
+#        with:
+#          files: "/tmp/alerting_benchmarks.json"
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -1,0 +1,52 @@
+name: "Benchmark workflow"
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+permissions:
+  contents: write
+  deployments: write
+jobs:
+  paton:
+    name: paton
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-go@v3
+        with:
+          go-version-file: 'go.mod'
+      - run: go get golang.org/x/perf/cmd/benchstat
+      - run: sudo apt-get update
+      - run: sudo apt-get -y -q install jc jq
+      - run: sh scripts/travis/before_build.sh # Installs libsodium.
+      - name: Run benchmark
+        run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
+        shell: bash
+      - name: Push benchmark result to gh-pages branch
+        if: github.event_name == 'push'
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'customSmallerIsBetter'
+          output-file-path: benchmark_output.txt
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+      - name: Evaluate benchmark on PR branch
+        if: github.event.pull_request
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Go Benchmark
+          tool: 'customSmallerIsBetter'
+          output-file-path: /tmp/benchstat_time_jq.json
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          alert-threshold: '10%'
+          comment-on-alert: true
+ #     - name: Slack Notification
+ #       env:
+ #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+ #       run: |
+ #         curl -X POST --data-urlencode "payload={\"text\": \"Benchmark workflow failed. ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} \"}" $SLACK_WEBHOOK
+  #      if: ${{ failure() && (contains(github.ref_name, 'rel/nightly') || contains(github.ref_name, 'rel/beta') || contains(github.ref_name, 'rel/stable') || contains(github.ref_name, 'master')) }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -24,11 +24,9 @@ jobs:
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq
-      - run: |
-        scripts/configure_dev.sh
-        scripts/buildtools/install_buildtools.sh
-        scripts/travis/before_build.sh # Installs libsodium.
-        shell: bash
+      - run: sh scripts/configure_dev.sh
+      - run: sh scripts/buildtools/install_buildtools.sh
+      - run: sh scripts/travis/before_build.sh # Installs libsodium.
       - name: Run benchmark
         run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -33,7 +33,7 @@ jobs:
       - run: ./scripts/travis/before_build.sh # Installs libsodium.
         shell: bash
       - name: Run benchmark
-        run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
+        run: ./scripts/paton.sh --alert-threshold-pct 10 --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash
       - name: Check files
         id: check_files

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'
-      - run: go get golang.org/x/perf/cmd/benchstat
+      - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq
       - run: sh scripts/travis/before_build.sh # Installs libsodium.

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -24,8 +24,12 @@ jobs:
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jc jq
-      - run: sh scripts/buildtools/install_buildtools.sh
-      - run: sh scripts/travis/before_build.sh # Installs libsodium.
+      - run: ./scripts/configure_dev.sh
+        shell: bash
+      - run: ./scripts/buildtools/install_buildtools.sh
+        shell: bash
+      - run: ./scripts/travis/before_build.sh # Installs libsodium.
+        shell: bash
       - name: Run benchmark
         run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -35,25 +35,17 @@ jobs:
       - name: Run benchmark
         run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
         shell: bash
-      - name: Push benchmark result to gh-pages branch
-        if: github.event_name == 'push'
-        uses: benchmark-action/github-action-benchmark@v1
+      - name: Check files
+        id: check_files
+        uses: andstor/file-existence-action@v1
         with:
-          name: Go Benchmark
-          tool: 'customSmallerIsBetter'
-          output-file-path: /tmp/benchstat_time_jq.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          auto-push: true
-      - name: Evaluate benchmark on PR branch
-        if: github.event.pull_request
-        uses: benchmark-action/github-action-benchmark@v1
+          files: "/tmp/alerting_benchmarks.json"
+      - name: Add PR comment
+        if: steps.check_files.outputs.files_exists == 'true'
+        uses: peter-evans/create-or-update-comment@v2
         with:
-          name: Go Benchmark
-          tool: 'customSmallerIsBetter'
-          output-file-path: /tmp/benchstat_time_jq.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '10%'
-          comment-on-alert: true
+          issue-number: ${{ github.event.number }}
+          body-file: /tmp/alerting_benchmarks.json
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -4,8 +4,9 @@ on:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+# For demonstration purposes, allow paton to run on all PRs.
+#    branches:
+#      - master
 permissions:
   contents: write
   deployments: write

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        - fetch-depth: 2
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -34,7 +34,7 @@ jobs:
         with:
           name: Go Benchmark
           tool: 'customSmallerIsBetter'
-          output-file-path: benchmark_output.txt
+          output-file-path: /tmp/benchstat_time_jq.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
       - name: Evaluate benchmark on PR branch

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        - fetch-depth: 2
+        fetch-depth: 2
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -43,16 +43,16 @@ jobs:
           output-file-path: /tmp/benchstat_time_jq.json
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
-      - name: Evaluate benchmark on PR branch
-        if: github.event.pull_request
-        uses: benchmark-action/github-action-benchmark@v1
-        with:
-          name: Go Benchmark
-          tool: 'customSmallerIsBetter'
-          output-file-path: /tmp/benchstat_time_jq.json
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          alert-threshold: '10%'
-          comment-on-alert: true
+#      - name: Evaluate benchmark on PR branch
+#        if: github.event.pull_request
+#        uses: benchmark-action/github-action-benchmark@v1
+#        with:
+#          name: Go Benchmark
+#          tool: 'customSmallerIsBetter'
+#          output-file-path: /tmp/benchstat_time_jq.json
+#          github-token: ${{ secrets.GITHUB_TOKEN }}
+#          alert-threshold: '10%'
+#          comment-on-alert: true
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -31,7 +31,7 @@ jobs:
       - run: go install golang.org/x/perf/cmd/benchstat@latest
       - run: sudo apt-get update
       - run: sudo apt-get -y -q install jq python3-pip
-      - run: pip3 install jc # Use pip to install jc because aptitude is stale (https://repology.org/project/jc/versions)
+      - run: pip3 install jc # Use pip to install jc because aptitude is stale (https://repology.org/project/jc/versions).
       - run: ./scripts/configure_dev.sh
         shell: bash
       - run: ./scripts/buildtools/install_buildtools.sh
@@ -47,7 +47,7 @@ jobs:
         with:
           files: "/tmp/alerting_benchmarks.json"
       - name: Add PR comment
-        if: steps.check_files.outputs.files_exists == 'true'
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_files.outputs.files_exists == 'true'
         uses: peter-evans/create-or-update-comment@v2
         with:
           issue-number: ${{ github.event.number }}

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -16,7 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        fetch-depth: 2
+        with:
+          fetch-depth: 0
       - uses: actions/setup-go@v3
         with:
           go-version-file: 'go.mod'

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -31,9 +31,9 @@ jobs:
         shell: bash
       - run: ./scripts/travis/before_build.sh # Installs libsodium.
         shell: bash
-      - name: Run benchmark
-        run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
-        shell: bash
+ #     - name: Run benchmark
+ #       run: ./scripts/paton.sh --test-cmd "-run XXX -benchtime 5s -bench BenchmarkControl ./data/transactions/logic"
+ #       shell: bash
       - name: Push benchmark result to gh-pages branch
         if: github.event_name == 'push'
         uses: benchmark-action/github-action-benchmark@v1

--- a/.github/workflows/paton.yml
+++ b/.github/workflows/paton.yml
@@ -46,12 +46,16 @@ jobs:
         uses: andstor/file-existence-action@v1
         with:
           files: "/tmp/alerting_benchmarks.json"
-      - name: Add PR comment
-        if: github.event.pull_request.head.repo.full_name == github.repository && steps.check_files.outputs.files_exists == 'true'
-        uses: peter-evans/create-or-update-comment@v2
+      - uses: actions/github-script@v6
+        if: steps.check_files.outputs.files_exists == 'true'
         with:
-          issue-number: ${{ github.event.number }}
-          body-file: /tmp/alerting_benchmarks.json
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Performance degraded!'
+            })
  #     - name: Slack Notification
  #       env:
  #         SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -25,6 +25,7 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -3724,6 +3725,28 @@ main:
 			b.ReportAllocs()
 			benchmarkOperation(b, bench[1], bench[2], bench[3])
 		})
+	}
+}
+
+func BenchmarkControl1(b *testing.B) {
+	var arr []int
+	for i := 0; i < b.N; i++ {
+		time.Sleep(25 * time.Millisecond)
+		arr = make([]int, 25)
+	}
+	if b.N < 0 {
+		fmt.Println(arr)
+	}
+}
+
+func BenchmarkControl2(b *testing.B) {
+	var arr []int
+	for i := 0; i < b.N; i++ {
+		time.Sleep(10 * time.Millisecond)
+		arr = make([]int, 10)
+	}
+	if b.N < 0 {
+		fmt.Println(arr)
 	}
 }
 

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,8 +3731,8 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(25 * time.Millisecond)
-		arr = make([]int, 25)
+		time.Sleep(50 * time.Millisecond)
+		arr = make([]int, 50)
 	}
 	if b.N < 0 {
 		fmt.Println(arr)
@@ -3742,8 +3742,8 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(10 * time.Millisecond)
-		arr = make([]int, 10)
+		time.Sleep(25 * time.Millisecond)
+		arr = make([]int, 25)
 	}
 	if b.N < 0 {
 		fmt.Println(arr)

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(175 * time.Millisecond)
+		time.Sleep(75 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {
@@ -3742,7 +3742,7 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(125 * time.Millisecond)
+		time.Sleep(45 * time.Millisecond)
 		arr = make([]int, 25)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(75 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {
@@ -3742,7 +3742,7 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(25 * time.Millisecond)
+		time.Sleep(45 * time.Millisecond)
 		arr = make([]int, 25)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(225 * time.Millisecond)
+		time.Sleep(300 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(75 * time.Millisecond)
+		time.Sleep(125 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {
@@ -3742,7 +3742,7 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(45 * time.Millisecond)
+		time.Sleep(75 * time.Millisecond)
 		arr = make([]int, 25)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(125 * time.Millisecond)
+		time.Sleep(150 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {
@@ -3742,7 +3742,7 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(75 * time.Millisecond)
+		time.Sleep(100 * time.Millisecond)
 		arr = make([]int, 25)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(75 * time.Millisecond)
+		time.Sleep(225 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {

--- a/data/transactions/logic/eval_test.go
+++ b/data/transactions/logic/eval_test.go
@@ -3731,7 +3731,7 @@ main:
 func BenchmarkControl1(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(150 * time.Millisecond)
+		time.Sleep(175 * time.Millisecond)
 		arr = make([]int, 50)
 	}
 	if b.N < 0 {
@@ -3742,7 +3742,7 @@ func BenchmarkControl1(b *testing.B) {
 func BenchmarkControl2(b *testing.B) {
 	var arr []int
 	for i := 0; i < b.N; i++ {
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(125 * time.Millisecond)
 		arr = make([]int, 25)
 	}
 	if b.N < 0 {

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -53,13 +53,7 @@ go test ${GO_TEST_CMD[*]} | tee /tmp/compare.txt
 
 benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
 
-cat /tmp/benchstat.txt |
-  awk '/old time\/op/{f=1} /^$/{f=0} f' |
-  jc -p --asciitable |
-  # Remove symbols (+, %) preventing conversion to JavaScript number.
-  sed '/delta/s/+//g' |
-  sed '/delta/s/%//g' |
-  tee /tmp/benchstat_time.json
+cat /tmp/benchstat.txt | awk '/old time\/op/{f=1} /^$/{f=0} f' | jc -p --asciitable | sed '/delta/s/+//g' | sed '/delta/s/%//g' | tee /tmp/benchstat_time.json
 
 cat /tmp/benchstat_time.json |
   jq '.[] | {

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+
+set -euf -o pipefail
+
+# Primarily intended for continuous benchmarking, paton.sh compares Go
+# benchmarks between 2 git commits and outputs the comparison in a format
+# compatible with https://github.com/benchmark-action/github-action-benchmark.
+#
+# paton.sh is inspired by https://github.com/knqyf263/cob.  cob minimizes
+# benchmarking variance by running provided benchmarks against 2 commits in 1
+# invocation rather than comparing against a previously stored result.
+# Comparing against a previously stored result requires a stable benchmark
+# environment across time.  Particularly in fully managed CI environments, a
+# stable benchmark environment cannot be guaranteed.
+#
+# paton.sh's namesake is https://en.wikipedia.org/wiki/Paton_Bridge.
+#
+# paton.sh requires these dependencies.  No attempt is made to install prerequisites:
+# * https://pkg.go.dev/golang.org/x/perf/cmd/benchstat
+# * https://github.com/stedolan/jq
+# * https://github.com/kellyjonbrazil/jc
+
+if [[ $# -lt 1 ]]; then
+  echo "Must provide required flags"
+  exit 1
+fi
+
+# Argument parsing crafted with help from https://stackoverflow.com/a/14203146.
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    -c|--test-cmd)
+      GO_TEST_CMD=("$2")
+      shift # past argument
+      shift # past value
+      ;;
+    *)
+      echo "Unknown flag"
+      exit 1
+      ;;
+  esac
+done
+
+BASE="HEAD~1"
+COMPARE="HEAD"
+
+COMPARE_COMMIT=$(git rev-parse "$COMPARE")
+
+git -c advice.detachedHead=false checkout "$BASE"
+go test ${GO_TEST_CMD[*]} > /tmp/base.txt
+
+git -c advice.detachedHead=false checkout "$COMPARE_COMMIT"
+go test ${GO_TEST_CMD[*]} > /tmp/compare.txt
+
+benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
+
+cat /tmp/benchstat.txt |
+  awk '/old time\/op/{f=1} /^$/{f=0} f' |
+  jc -p --asciitable |
+  # Remove symbols (+, %) preventing conversion to JavaScript number.
+  sed '/delta/s/+//g' |
+  sed '/delta/s/%//g' |
+  tee /tmp/benchstat_time.json
+
+cat /tmp/benchstat_time.json |
+  jq '.[] | {
+    name: (.name + "-"),
+    value: .delta | tonumber,
+    unit: "Percent"
+    }' |
+  jq -s > /tmp/benchstat_time_jq.json

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -2,9 +2,8 @@
 
 set -euxf -o pipefail
 
-# Primarily intended for continuous benchmarking, paton.sh compares Go
-# benchmarks between 2 git commits and outputs the comparison in a format
-# compatible with https://github.com/benchmark-action/github-action-benchmark.
+# Primarily intended for continuous benchmarking, paton.sh judges benchmark
+# performance across 2 git commits against a user-provided percent threshold.
 #
 # paton.sh is inspired by https://github.com/knqyf263/cob.  cob minimizes
 # benchmarking variance by running provided benchmarks against 2 commits in 1

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -79,6 +79,6 @@ cat /tmp/benchstat_time_jq.json |
   jq ".[] | select(.delta >= ${ALERT_THRESHOLD_PCT})" |
   tee /tmp/alerting_benchmarks.json
 
-if [ ! -s /tmp/alerting_benchmarks.json ]; then
-  rm /tmp/alerting_benchmarks.json
-fi
+#if [ ! -s /tmp/alerting_benchmarks.json ]; then
+#  rm /tmp/alerting_benchmarks.json
+#fi

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -53,7 +53,15 @@ go test ${GO_TEST_CMD[*]} | tee /tmp/compare.txt
 
 benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
 
-cat /tmp/benchstat.txt | awk '/old time\/op/{f=1} /^$/{f=0} f' | jc -p --asciitable | sed '/delta/s/+//g' | sed '/delta/s/%//g' | tee /tmp/benchstat_time.json
+cat /tmp/benchstat.txt |
+  awk '/old time\/op/{f=1} /^$/{f=0} f' > /tmp/benchstat_time.txt
+
+cat /tmp/benchstat_time.txt |
+  jc -p --asciitable |
+  # Remove symbols (+, %) preventing conversion to JavaScript number.
+  sed '/delta/s/+//g' |
+  sed '/delta/s/%//g' |
+  tee /tmp/benchstat_time.json
 
 cat /tmp/benchstat_time.json |
   jq '.[] | {

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -54,11 +54,13 @@ go test ${GO_TEST_CMD[*]} | tee /tmp/compare.txt
 benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
 
 cat /tmp/benchstat.txt |
-  awk '/old time\/op/{f=1} /^$/{f=0} f' > /tmp/benchstat_time.txt
+  awk '/old time\/op/{f=1} /^$/{f=0} f' | tee /tmp/benchstat_time.txt
 
 cat /tmp/benchstat_time.txt |
-  jc -p --asciitable |
-  # Remove symbols (+, %) preventing conversion to JavaScript number.
+  jc -p --asciitable | tee /tmp/benchstat_time_jc.json
+
+# Remove symbols (+, %) preventing conversion to JavaScript number.
+cat /tmp/benchstat_time_jc.json |
   sed '/delta/s/+//g' |
   sed '/delta/s/%//g' |
   tee /tmp/benchstat_time.json

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -euf -o pipefail
+set -euxf -o pipefail
 
 # Primarily intended for continuous benchmarking, paton.sh compares Go
 # benchmarks between 2 git commits and outputs the comparison in a format

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -46,10 +46,10 @@ COMPARE="HEAD"
 COMPARE_COMMIT=$(git rev-parse "$COMPARE")
 
 git -c advice.detachedHead=false checkout "$BASE"
-go test ${GO_TEST_CMD[*]} > /tmp/base.txt
+go test ${GO_TEST_CMD[*]} | tee /tmp/base.txt
 
 git -c advice.detachedHead=false checkout "$COMPARE_COMMIT"
-go test ${GO_TEST_CMD[*]} > /tmp/compare.txt
+go test ${GO_TEST_CMD[*]} | tee /tmp/compare.txt
 
 benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
 

--- a/scripts/paton.sh
+++ b/scripts/paton.sh
@@ -54,13 +54,9 @@ go test ${GO_TEST_CMD[*]} | tee /tmp/compare.txt
 benchstat -delta-test none /tmp/base.txt /tmp/compare.txt | tee /tmp/benchstat.txt
 
 cat /tmp/benchstat.txt |
-  awk '/old time\/op/{f=1} /^$/{f=0} f' | tee /tmp/benchstat_time.txt
-
-cat /tmp/benchstat_time.txt |
-  jc -p --asciitable | tee /tmp/benchstat_time_jc.json
-
-# Remove symbols (+, %) preventing conversion to JavaScript number.
-cat /tmp/benchstat_time_jc.json |
+  awk '/old time\/op/{f=1} /^$/{f=0} f' |
+  jc -p --asciitable |
+  # Remove symbols (+, %) preventing conversion to JavaScript number.
   sed '/delta/s/+//g' |
   sed '/delta/s/%//g' |
   tee /tmp/benchstat_time.json


### PR DESCRIPTION
Introduces paton as a continuous benchmarking tool.  For reasons described below, the PR is merged without showing a successful run because there's a one-time bootstrapping need.

The PR offers the following functionality:
*  `scripts/paton.sh` - Runs Go benchmarks across commits like https://github.com/knqyf263/cob to minimize environment variance.  The script is suitable for local and CI invocations.
* `.github/workflows/paton-benchmark.yml` - Github Actions (GHA) workflow that demonstrates `paton.sh` usage against a sample benchmark.  The usage configures a performance degradation threshold (`--alert-threshold-pct`) that outputs _only_ failing benchmarks.
* `.github/workflows/paton-comment.yml` - GHA workflow triggered by completion of `paton-benchmark.yml`.  It adds a PR comment for failing benchmarks.
  * https://securitylab.github.com/research/github-actions-preventing-pwn-requests/ explains why a discrete workflow is required for adding PR comments. 
  * Since https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_run carries a disclaimer that it _only_ runs _if the workflow file is on the default branch,_  this PR must be merged to bootstrap usage.